### PR TITLE
Add settings attribute & validations

### DIFF
--- a/DeskThingServer/src/shared/types/app.ts
+++ b/DeskThingServer/src/shared/types/app.ts
@@ -112,6 +112,7 @@ export interface SettingsString {
   value: string
   type: 'string'
   label: string
+  maxLength?: number
   description?: string
 }
 


### PR DESCRIPTION
Currently, if you set the `min`/`max` value on a number input, the user is not prevented from entering a number higher/lower than the set range. The `min`/`max` html attirbutes are only validated by the up/down arrows in the control. User's should be prevented from manually entering numbers outside of the set range.

As well, it'd be nice if users were told what the set range was. Added elements for this.
![image](https://github.com/user-attachments/assets/67dc3f58-2ee9-4a44-8852-13dba93d90d3)

Finally, it'd also be nice if you could optionally validate a `maxLength` attribute on the `string` settings type.