### PR TITLE
Add Settings Types

### DIFF
--- a/DeskThingServer/src/renderer/src/components/RankableList.tsx
+++ b/DeskThingServer/src/renderer/src/components/RankableList.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react'
+import { SettingOption } from '@shared/types'
+import { IconArrowDown, IconArrowUp } from '@renderer/assets/icons'
+
+type RankableListProps = {
+  options: SettingOption[]
+  value: string[]
+  onChange: (orderedOptions: string[]) => void
+}
+
+const RankableList: React.FC<RankableListProps> = ({ options, onChange, value }) => {
+  const [orderedOptions, setOrderedOptions] = useState<SettingOption[]>(options)
+
+  useEffect(() => {
+    // Sort options based on the value order
+    const sortedOptions = [...options].sort((a, b) => {
+      const aIndex = value.indexOf(a.value)
+      const bIndex = value.indexOf(b.value)
+      return aIndex - bIndex
+    })
+    setOrderedOptions(sortedOptions)
+  }, [options, value]) // Re-run when options or value change
+
+  const handleMoveUp = (index: number): void => {
+    if (index > 0) {
+      const newOptions = [...orderedOptions]
+      ;[newOptions[index], newOptions[index - 1]] = [newOptions[index - 1], newOptions[index]]
+      setOrderedOptions(newOptions)
+      onChange(newOptions.map((option) => option.value))
+    }
+  }
+
+  const handleMoveDown = (index: number): void => {
+    if (index < orderedOptions.length - 1) {
+      const newOptions = [...orderedOptions]
+      ;[newOptions[index], newOptions[index + 1]] = [newOptions[index + 1], newOptions[index]]
+      setOrderedOptions(newOptions)
+      onChange(newOptions.map((option) => option.value))
+    }
+  }
+
+  return (
+    <div className="w-full">
+      {orderedOptions.map((option, index) => (
+        <div
+          key={option.value}
+          className="flex gap-3 items-center hover:bg-zinc-950 justify-between w-full border-t relative border-gray-900"
+        >
+          <div className="flex-1 flex items-center">
+            <p className="cursor-help break-words max-w-xs">{option.label}</p>
+          </div>
+          <div className="p-1 flex flex-col items-center">
+            <button
+              onClick={() => handleMoveUp(index)}
+              className={`p-1 rounded-md hover:bg-zinc-800 ${index === 0 ? 'opacity-30 cursor-not-allowed' : ''}`}
+            >
+              <IconArrowUp className="stroke-2 text-gray-400" />
+            </button>
+            <button
+              onClick={() => handleMoveDown(index)}
+              className={`p-1 rounded-md hover:bg-zinc-800 ${
+                index === orderedOptions.length - 1 ? 'opacity-30 cursor-not-allowed' : ''
+              }`}
+            >
+              <IconArrowDown className="stroke-2 text-gray-400" />
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default RankableList

--- a/DeskThingServer/src/renderer/src/overlays/apps/AppSettings.tsx
+++ b/DeskThingServer/src/renderer/src/overlays/apps/AppSettings.tsx
@@ -6,6 +6,7 @@ import Button from '@renderer/components/Button'
 import { IconLoading, IconSave, IconToggle } from '@renderer/assets/icons'
 import Select from '@renderer/components/Select'
 import { MultiValue, SingleValue } from 'react-select'
+import RankableList from '@renderer/components/RankableList'
 
 const AppSettings: React.FC<AppSettingProps> = ({ app }) => {
   const getAppData = useAppStore((state) => state.getAppData)
@@ -151,6 +152,22 @@ const AppSettings: React.FC<AppSettingProps> = ({ app }) => {
                       const selectedValues = selected as MultiValue<SettingOption>
                       const currentValues = selectedValues.map((value) => value.value)
                       handleSettingChange(key, currentValues)
+                    }}
+                  />
+                </div>
+              )}
+            </SettingComponent>
+          )
+        case 'ranked':
+          return (
+            <SettingComponent key={key} setting={setting}>
+              {setting.type == 'ranked' && (
+                <div className="w-96 max-w-s">
+                  <RankableList
+                    options={setting.options}
+                    value={setting.value}
+                    onChange={(rankedValues) => {
+                      handleSettingChange(key, rankedValues)
                     }}
                   />
                 </div>

--- a/DeskThingServer/src/renderer/src/overlays/apps/AppSettings.tsx
+++ b/DeskThingServer/src/renderer/src/overlays/apps/AppSettings.tsx
@@ -103,6 +103,22 @@ const AppSettings: React.FC<AppSettingProps> = ({ app }) => {
               </Button>
             </SettingComponent>
           )
+        case 'range':
+          return (
+            <SettingComponent key={key} setting={setting}>
+              {setting.type == 'range' && (
+                <input
+                  type="range"
+                  value={setting.value}
+                  min={setting.min}
+                  max={setting.max}
+                  step={setting.step || 1}
+                  onChange={(e) => handleSettingChange(key, e.target.value)}
+                  className="w-96 max-w-s"
+                />
+              )}
+            </SettingComponent>
+          )
         case 'select':
           return (
             <SettingComponent key={key} setting={setting}>
@@ -181,7 +197,7 @@ const AppSettings: React.FC<AppSettingProps> = ({ app }) => {
   }
 
   return (
-    <div className="w-full h-full p-6 flex flex-col overflow-x-hidden">
+    <div className="w-full h-full p-6 flex flex-col">
       {settingsEntries.map(([key, setting]) => renderSettingInput(setting, key))}
       <div className="border-t mt-4 py-5 border-gray-900 w-full flex justify-end">
         <Button
@@ -226,7 +242,10 @@ const SettingComponent = ({ setting, children, className }: SettingComponentProp
           )}
         </div>
       </div>
-      {children}
+      <div className="flex flex-col items-center">
+        {setting.type === 'range' && <div>{setting.value}</div>}
+        {children}
+      </div>
     </div>
   )
 }

--- a/DeskThingServer/src/shared/types/app.ts
+++ b/DeskThingServer/src/shared/types/app.ts
@@ -140,6 +140,14 @@ export type SettingOption = {
   value: string
 }
 
+export interface SettingsRanked {
+  value: string[]
+  type: 'ranked'
+  label: string
+  description?: string
+  options: SettingOption[]
+}
+
 export interface SettingsMultiSelect {
   value: string[]
   type: 'multiselect'
@@ -156,6 +164,7 @@ export type SettingsType =
   | SettingsSelect
   | SettingsMultiSelect
   | SettingsRange
+  | SettingsRanked
 
 export interface AppSettings {
   [key: string]: SettingsType

--- a/DeskThingServer/src/shared/types/app.ts
+++ b/DeskThingServer/src/shared/types/app.ts
@@ -108,6 +108,16 @@ export interface SettingsBoolean {
   description?: string
 }
 
+export interface SettingsRange {
+  value: number
+  type: 'range'
+  label: string
+  min: number
+  max: number
+  step?: number
+  description?: string
+}
+
 export interface SettingsString {
   value: string
   type: 'string'
@@ -145,6 +155,7 @@ export type SettingsType =
   | SettingsString
   | SettingsSelect
   | SettingsMultiSelect
+  | SettingsRange
 
 export interface AppSettings {
   [key: string]: SettingsType


### PR DESCRIPTION
It'd be nice to have more options for settings. I took the liberty to create a `range` & `ranked` setting type.

The `range` setting type will allow users select a number using a range control. It's `value` is an number.

The `ranked` setting type will allow users to order a list of options from highest to lowest. It's `value` is an array ordered by the user's seleted ranks.

See screenshots:
![range-setting](https://github.com/user-attachments/assets/f9dc60e7-395d-41e5-9990-3d5a10b29b1e)
![ranked-setting](https://github.com/user-attachments/assets/11003ae5-8768-49f2-94f1-913db8e98536)
