### PR TITLE
Fix false "Incompatible Platform" flag for apps with legacy platform identifiers

### DIFF
--- a/DeskThingServer/src/main/services/apps/appValidator.ts
+++ b/DeskThingServer/src/main/services/apps/appValidator.ts
@@ -23,6 +23,7 @@ import {
   CommonSetting 
 } from '@deskthing/types'
 import { AppData, LegacyAppData } from '@shared/types'
+import { normalizePlatforms } from '@shared/utils/platformUtils'
 
 // Utils
 import Logger from '@server/utils/logger'
@@ -421,7 +422,7 @@ export const constructManifest = (manifestData?: Partial<AppManifest>): AppManif
     version: manifestData?.version || '0.0.0',
     description: manifestData?.description || 'No description available',
     author: manifestData?.author || 'Unknown Author',
-    platforms: manifestData?.platforms || Object.values(PlatformTypes),
+    platforms: normalizePlatforms(manifestData?.platforms) || Object.values(PlatformTypes),
     homepage: manifestData?.homepage || '',
     repository: manifestData?.repository || '',
     updateUrl: manifestData?.updateUrl || manifestData?.repository || '',

--- a/DeskThingServer/src/renderer/src/overlays/SuccessNotification.tsx
+++ b/DeskThingServer/src/renderer/src/overlays/SuccessNotification.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { useAppStore, useClientStore } from '@renderer/stores'
 import { App, PlatformTypes } from '@deskthing/types'
 import { ProgressChannel, StagedAppManifest } from '@shared/types'
+import { normalizePlatforms } from '@shared/utils/platformUtils'
 import { LogEntry } from '@renderer/components/LogEntry'
 import { useChannelProgress } from '@renderer/hooks/useProgress'
 
@@ -49,7 +50,7 @@ const checkCompatibility = (
         ? PlatformTypes.MAC
         : PlatformTypes.LINUX
 
-  if (!manifest.platforms?.includes(currentPlatform)) {
+  if (!normalizePlatforms(manifest.platforms)?.includes(currentPlatform)) {
     compResult.isCompatible = false
     compResult.issues.push({
       title: 'Incompatible Platform',

--- a/DeskThingServer/src/renderer/src/overlays/apps/AppUpdate.tsx
+++ b/DeskThingServer/src/renderer/src/overlays/apps/AppUpdate.tsx
@@ -10,6 +10,7 @@ import {
 } from '@renderer/assets/icons'
 import { LogEntry } from '@renderer/components/LogEntry'
 import { ProgressChannel, StagedAppManifest } from '@shared/types'
+import { normalizePlatforms } from '@shared/utils/platformUtils'
 import { useChannelProgress } from '@renderer/hooks/useProgress'
 import { useAppStore, useClientStore, useReleaseStore } from '@renderer/stores'
 import { App, PlatformTypes } from '@deskthing/types'
@@ -53,7 +54,7 @@ const checkCompatibility = (
         ? PlatformTypes.MAC
         : PlatformTypes.LINUX
 
-  if (!manifest.platforms?.includes(currentPlatform)) {
+  if (!normalizePlatforms(manifest.platforms)?.includes(currentPlatform)) {
     compResult.isCompatible = false
     compResult.issues.push({
       title: 'Incompatible Platform',

--- a/DeskThingServer/src/shared/utils/platformUtils.ts
+++ b/DeskThingServer/src/shared/utils/platformUtils.ts
@@ -1,0 +1,31 @@
+import { PlatformTypes } from '@deskthing/types'
+
+/**
+ * Platform identifiers that have appeared in published app manifests but are not
+ * valid PlatformTypes values, mapped to their canonical equivalents.
+ * e.g. Spotify v0.11.1 and other pre-0.11.2 app releases shipped "macos", which
+ * made them appear incompatible on mac even though they run fine.
+ */
+const LEGACY_PLATFORM_ALIASES: Record<string, PlatformTypes> = {
+  macos: PlatformTypes.MAC,
+  osx: PlatformTypes.MAC,
+  darwin: PlatformTypes.MAC,
+  win: PlatformTypes.WINDOWS,
+  win32: PlatformTypes.WINDOWS
+}
+
+/**
+ * Normalizes a manifest's platform list, translating legacy identifiers
+ * (e.g. "macos") to their canonical PlatformTypes values and lowercasing
+ * case variants. Unrecognized values are preserved as-is.
+ *
+ * @param platforms The platforms array from an app manifest, if any
+ * @returns The normalized platforms array, or undefined if none was provided
+ */
+export const normalizePlatforms = (
+  platforms: (PlatformTypes | string)[] | undefined
+): PlatformTypes[] | undefined =>
+  platforms?.map((platform) => {
+    const lowered = String(platform).toLowerCase()
+    return LEGACY_PLATFORM_ALIASES[lowered] ?? (lowered as PlatformTypes)
+  })

--- a/DeskThingServer/test/main/services/appValidator.test.ts
+++ b/DeskThingServer/test/main/services/appValidator.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest'
+import { constructManifest } from '../../../src/main/services/apps/appValidator'
+import { PlatformTypes } from '@deskthing/types'
+
+vi.mock('@server/utils/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() }
+}))
+
+describe('constructManifest', () => {
+  it('normalizes legacy platform identifiers from published app manifests', () => {
+    // Verbatim platforms list from the published spotify-v0.11.1.zip manifest,
+    // which shipped "macos" and was flagged incompatible on mac
+    const manifest = constructManifest({
+      id: 'spotify',
+      version: '0.11.1',
+      platforms: ['windows', 'linux', 'macos'] as PlatformTypes[]
+    })
+
+    expect(manifest.platforms).toEqual([
+      PlatformTypes.WINDOWS,
+      PlatformTypes.LINUX,
+      PlatformTypes.MAC
+    ])
+    expect(manifest.platforms).toContain(PlatformTypes.MAC)
+  })
+
+  it('defaults to all platforms when none are declared', () => {
+    const manifest = constructManifest({ id: 'test' })
+    expect(manifest.platforms).toEqual(Object.values(PlatformTypes))
+  })
+})

--- a/DeskThingServer/test/main/services/platformUtils.test.ts
+++ b/DeskThingServer/test/main/services/platformUtils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { normalizePlatforms } from '@shared/utils/platformUtils'
+import { PlatformTypes } from '@deskthing/types'
+
+describe('normalizePlatforms', () => {
+  it('translates the legacy "macos" identifier to PlatformTypes.MAC', () => {
+    // Spotify v0.11.1 and other pre-0.11.2 published apps shipped this manifest value
+    expect(normalizePlatforms(['windows', 'linux', 'macos'])).toEqual([
+      PlatformTypes.WINDOWS,
+      PlatformTypes.LINUX,
+      PlatformTypes.MAC
+    ])
+  })
+
+  it('translates other known aliases and case variants', () => {
+    expect(normalizePlatforms(['osx', 'darwin', 'win', 'win32', 'MacOS'])).toEqual([
+      PlatformTypes.MAC,
+      PlatformTypes.MAC,
+      PlatformTypes.WINDOWS,
+      PlatformTypes.WINDOWS,
+      PlatformTypes.MAC
+    ])
+  })
+
+  it('leaves canonical values untouched', () => {
+    const canonical = Object.values(PlatformTypes)
+    expect(normalizePlatforms(canonical)).toEqual(canonical)
+  })
+
+  it('preserves unrecognized values rather than dropping them', () => {
+    expect(normalizePlatforms(['toaster'])).toEqual(['toaster'])
+  })
+
+  it('returns undefined when no platforms are provided', () => {
+    expect(normalizePlatforms(undefined)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Problem

Published app releases declare `"macos"` in their manifest `platforms` list, which is not a valid `PlatformTypes` value. On macOS the compatibility check looks for `"mac"`, so these apps are falsely flagged **"App not compatible with mac platform"** even though they run fine.

This affects the entire current app-release wave, not just one app:
- `spotify-v0.11.1.zip` ships `["windows", "linux", "macos"]`
- `weatherwaves-v0.11.2.zip` (different author/repo) ships `["windows", "macos", "linux"]`

Every macOS user installing these apps sees the scary warning and has to acknowledge past it. The manifests in `deskthing-apps` master are already corrected, but all currently-published release zips still carry the legacy string — and third-party app repos will keep shipping it for a while.

## Fix

Adds a shared `normalizePlatforms` helper that translates legacy identifiers (`macos`/`osx`/`darwin` → `mac`, `win`/`win32` → `windows`) and lowercases case variants, applied in:

- `constructManifest` (server-side manifest parsing, covers staged installs and stored apps)
- `checkCompatibility` in `SuccessNotification.tsx` and `AppUpdate.tsx` (renderer-side checks that receive release metadata directly)

Unrecognized values are preserved as-is, and the default of "all platforms" when none are declared is unchanged.

## Testing

- New unit tests for `normalizePlatforms`, including one that runs the verbatim platforms list from the published `spotify-v0.11.1.zip` through `constructManifest` and asserts it comes out mac-compatible
- `npm run typecheck` passes both configs
- Verified end-to-end on an arm64 Mac: with this patch, downloading Spotify v0.11.1 shows no "Incompatible Platform" warning; on stock 0.11.17 the warning appears. The app itself runs fine on macOS once installed (confirmed with a flashed Car Thing playing music)

🤖 Generated with [Claude Code](https://claude.com/claude-code)